### PR TITLE
Mark repository as obsolete and provide redirect

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+The functionality of this repository has been included in the new version of the [SEM-FIB-Tomography Mapper](https://github.com/kit-data-manager/tomo_mapper). This repository is now obsolete.
+
 # pp13-mapper
 
 This will function as a repository for development of the PP13 plugin of the [mapping service](https://github.com/kit-data-manager/mapping-service)


### PR DESCRIPTION
Indicate that the repository is obsolete and redirect to the new version.